### PR TITLE
To enable windows to build at javadoc-plugin section.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.4.1</version>
                 <configuration>
-                    <javadocExecutable>/usr/bin/javadoc</javadocExecutable>
+                    <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
                     <!--<show>private</show>-->
                     <nohelp>true</nohelp>
                 </configuration>


### PR DESCRIPTION
Only checked windows/Java 11 in Cdrive. But I think it works for Mac/Unix also. Checked Internet information.