### PR TITLE
Enables Maven test to work on windows. 

### DIFF
--- a/src/test/java/edu/pitt/dbmi/causal/cmd/CausalCmdApplicationExternalGraphTest.java
+++ b/src/test/java/edu/pitt/dbmi/causal/cmd/CausalCmdApplicationExternalGraphTest.java
@@ -1,5 +1,6 @@
 package edu.pitt.dbmi.causal.cmd;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
@@ -18,10 +19,10 @@ public class CausalCmdApplicationExternalGraphTest {
 
     @Test
     public void testRSkewWithContinuousData() throws IOException {
-        String dataset = CausalCmdApplicationExternalGraphTest.class
-                .getResource("/data/graph_data/sim_cont_10var_1kcase/data/data.txt").getFile();
-        String graph = CausalCmdApplicationExternalGraphTest.class
-                .getResource("/data/graph_data/sim_cont_10var_1kcase/graph/graph.txt").getFile();
+        String dataset = new File(CausalCmdApplicationExternalGraphTest.class
+                .getResource("/data/graph_data/sim_cont_10var_1kcase/data/data.txt").getFile()).getAbsolutePath();
+        String graph = new File(CausalCmdApplicationExternalGraphTest.class
+                .getResource("/data/graph_data/sim_cont_10var_1kcase/graph/graph.txt").getFile()).getAbsolutePath();
 
         String dirOut = TestFiles.createSubDir(tempDir, "rskew_cont_ext_graph").toString();
         String[] args = {
@@ -39,10 +40,10 @@ public class CausalCmdApplicationExternalGraphTest {
 
     @Test
     public void testFgesWithContinuousData() throws IOException {
-        String dataset = CausalCmdApplicationExternalGraphTest.class
-                .getResource("/data/graph_data/sim_cont_10var_1kcase/data/data.txt").getFile();
-        String graph = CausalCmdApplicationExternalGraphTest.class
-                .getResource("/data/graph_data/sim_cont_10var_1kcase/graph/graph.txt").getFile();
+        String dataset = new File(CausalCmdApplicationExternalGraphTest.class
+                .getResource("/data/graph_data/sim_cont_10var_1kcase/data/data.txt").getFile()).getAbsolutePath();
+        String graph = new File(CausalCmdApplicationExternalGraphTest.class
+                .getResource("/data/graph_data/sim_cont_10var_1kcase/graph/graph.txt").getFile()).getAbsolutePath();
 
         String dirOut = TestFiles.createSubDir(tempDir, "fges_cont_ext_graph").toString();
         String[] args = {

--- a/src/test/java/edu/pitt/dbmi/causal/cmd/TestFiles.java
+++ b/src/test/java/edu/pitt/dbmi/causal/cmd/TestFiles.java
@@ -18,6 +18,7 @@
  */
 package edu.pitt.dbmi.causal.cmd;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -33,53 +34,54 @@ import java.util.List;
  */
 final class TestFiles {
 
-    public static final String CONTINUOUS_DATA = TestFiles.class
-            .getResource("/data/sim_data_continuous_20var_100case.txt").getFile();
 
-    public static final String CONTINUOUS_10VAR_1KCASE_MISSING_DATA = TestFiles.class
-            .getResource("/data/sim_data_continuous_10var_1kcase_missing.csv").getFile();
+    public static final String CONTINUOUS_DATA = new File(TestFiles.class
+            .getResource("/data/sim_data_continuous_20var_100case.txt").getFile()).getAbsolutePath();
 
-    public static final String CONTINUOUS_DATA_NO_HEADER = TestFiles.class
-            .getResource("/data/sim_data_continuous_20var_100case_no_header.txt").getFile();
+    public static final String CONTINUOUS_10VAR_1KCASE_MISSING_DATA = new File(TestFiles.class
+            .getResource("/data/sim_data_continuous_10var_1kcase_missing.csv").getFile()).getAbsolutePath();
 
-    public static final String CONTINUOUS_DATA_20K_PART1 = TestFiles.class
-            .getResource("/data/sim_data_continuous_20var_100case_part_1.txt").getFile();
+    public static final String CONTINUOUS_DATA_NO_HEADER = new File(TestFiles.class
+            .getResource("/data/sim_data_continuous_20var_100case_no_header.txt").getFile()).getAbsolutePath();
 
-    public static final String CONTINUOUS_DATA_20K_PART2 = TestFiles.class
-            .getResource("/data/sim_data_continuous_20var_100case_part_2.txt").getFile();
+    public static final String CONTINUOUS_DATA_20K_PART1 = new File(TestFiles.class
+            .getResource("/data/sim_data_continuous_20var_100case_part_1.txt").getFile()).getAbsolutePath();
 
-    public static final String DISCRETE_DATA = TestFiles.class
-            .getResource("/data/sim_data_discrete_20var_100case.txt").getFile();
+    public static final String CONTINUOUS_DATA_20K_PART2 = new File(TestFiles.class
+            .getResource("/data/sim_data_continuous_20var_100case_part_2.txt").getFile()).getAbsolutePath();
 
-    public static final String MIXED_DATA = TestFiles.class
-            .getResource("/data/sim_data_mixed_20var_100case.txt").getFile();
+    public static final String DISCRETE_DATA = new File(TestFiles.class
+            .getResource("/data/sim_data_discrete_20var_100case.txt").getFile()).getAbsolutePath();
 
-    public static final String COVARIANCE_CONTINUOUS_DATA = TestFiles.class
-            .getResource("/data/covariance_sim_data_continuous_20var_100case.txt").getFile();
+    public static final String MIXED_DATA = new File(TestFiles.class
+            .getResource("/data/sim_data_mixed_20var_100case.txt").getFile()).getAbsolutePath();
 
-    public static final String KNOWLEDGE_CONTINUOUS_DATA = TestFiles.class
-            .getResource("/data/knowledge_sim_data_continuous_20var_100case.txt").getFile();
+    public static final String COVARIANCE_CONTINUOUS_DATA = new File(TestFiles.class
+            .getResource("/data/covariance_sim_data_continuous_20var_100case.txt").getFile()).getAbsolutePath();
 
-    public static final String EXCLUDE_VARIABLES = TestFiles.class
-            .getResource("/data/exclude_vars.txt").getFile();
+    public static final String KNOWLEDGE_CONTINUOUS_DATA = new File(TestFiles.class
+            .getResource("/data/knowledge_sim_data_continuous_20var_100case.txt").getFile()).getAbsolutePath();
 
-    public static final String CONTINUOUS_INTERVENTIONAL_DATA = TestFiles.class
-            .getResource("/data/metadata/sim_continuous_intervention.txt").getFile();
+    public static final String EXCLUDE_VARIABLES = new File(TestFiles.class
+            .getResource("/data/exclude_vars.txt").getFile()).getAbsolutePath();
 
-    public static final String DISCRETE_INTERVENTIONAL_DATA = TestFiles.class
-            .getResource("/data/metadata/sim_discrete_intervention.txt").getFile();
+    public static final String CONTINUOUS_INTERVENTIONAL_DATA = new File(TestFiles.class
+            .getResource("/data/metadata/sim_continuous_intervention.txt").getFile()).getAbsolutePath();
 
-    public static final String MIXED_INTERVENTIONAL_DATA = TestFiles.class
-            .getResource("/data/metadata/sim_mixed_intervention.txt").getFile();
+    public static final String DISCRETE_INTERVENTIONAL_DATA = new File(TestFiles.class
+            .getResource("/data/metadata/sim_discrete_intervention.txt").getFile()).getAbsolutePath();
 
-    public static final String CONTINUOUS_INTERVENTIONAL_METADATA = TestFiles.class
-            .getResource("/data/metadata/sim_continuous_intervention_metadata.json").getFile();
+    public static final String MIXED_INTERVENTIONAL_DATA = new File(TestFiles.class
+            .getResource("/data/metadata/sim_mixed_intervention.txt").getFile()).getAbsolutePath();
 
-    public static final String DISCRETE_INTERVENTIONAL_METADATA = TestFiles.class
-            .getResource("/data/metadata/sim_discrete_intervention_metadata.json").getFile();
+    public static final String CONTINUOUS_INTERVENTIONAL_METADATA = new File(TestFiles.class
+            .getResource("/data/metadata/sim_continuous_intervention_metadata.json").getFile()).getAbsolutePath();
 
-    public static final String MIXED_INTERVENTIONAL_METADATA = TestFiles.class
-            .getResource("/data/metadata/sim_mixed_intervention_metadata.json").getFile();
+    public static final String DISCRETE_INTERVENTIONAL_METADATA = new File(TestFiles.class
+            .getResource("/data/metadata/sim_discrete_intervention_metadata.json").getFile()).getAbsolutePath();
+
+    public static final String MIXED_INTERVENTIONAL_METADATA = new File(TestFiles.class
+            .getResource("/data/metadata/sim_mixed_intervention_metadata.json").getFile()).getAbsolutePath();
 
     private TestFiles() {
     }


### PR DESCRIPTION
This will be good for windows users to test tetrad and causal-cmd.

Conventional case on windows:
/E:/GitLab/causal-cmd/target/test-classes/data/sim_data_continuous_20var_100case.txt

New case on windows:
E:/GitLab/causal-cmd/target/test-classes/data/sim_data_continuous_20var_100case.txt